### PR TITLE
敵の種類選択コンボボックスを追加

### DIFF
--- a/TD3_1/Src/Application/EnemySpawnManager/EnemySpawnManager.cpp
+++ b/TD3_1/Src/Application/EnemySpawnManager/EnemySpawnManager.cpp
@@ -353,6 +353,10 @@ void EnemySpawnManager::nDrawSpawnEditor()
 					// 敵の種類
 					static const char* enemyTypes[] = { "Normal" , "Empty" };
 					static int selectedEnemyTypeIndex = 0;
+
+                    if (enemy.enemyType == "Normal") selectedEnemyTypeIndex = 0;
+                    else if (enemy.enemyType == "Empty") selectedEnemyTypeIndex = 1;
+
 					if (ImGui::Combo("Type", &selectedEnemyTypeIndex, enemyTypes, IM_ARRAYSIZE(enemyTypes))) {
 						enemy.enemyType = enemyTypes[selectedEnemyTypeIndex];
 					}


### PR DESCRIPTION
`EnemySpawnManager::nDrawSpawnEditor()` 関数に、敵の種類を選択するためのコンボボックスを追加しました。選択された敵の種類に基づいて `selectedEnemyTypeIndex` を設定し、ユーザーが "Normal" または "Empty" のいずれかを選択できるようにしました。選択が変更されると、`enemy.enemyType` に新しい値が反映されます。